### PR TITLE
Add simple landing and order pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A modern starter based on Astro.js, Tailwind, daisyUI, and [Netlify Core Primitives](https://docs.netlify.com/core/overview/#develop) (Edge Functions, Image CDN, Blob Store).
 
+This repository demonstrates a simple landing page at `/` and an order form at `/order`.
+
 ## Astro Commands
 
 All commands are run from the root of the project, from a terminal:

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,7 +6,8 @@ const navItems = [
     { linkText: 'Revalidation', href: '/revalidation' },
     { linkText: 'Image CDN', href: '/image-cdn' },
     { linkText: 'Edge Function', href: '/edge' },
-    { linkText: 'Blobs', href: '/blobs' }
+    { linkText: 'Blobs', href: '/blobs' },
+    { linkText: 'Order', href: '/order' }
 ];
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,21 +1,9 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import ContextAlert from '../components/ContextAlert.astro';
-import Markdown from '../components/Markdown.astro';
-
-const explainer = `
-An Astro website can go way beyond static pages - on the right platform.
-
-Netlify supports not only [Streaming SSR](https://docs.astro.build/en/guides/server-side-rendering/#html-streaming) and fast [Edge Middleware](https://docs.astro.build/en/guides/middleware/), but also [on-demand revalidation](https://www.netlify.com/blog/cache-tags-and-purge-api-on-netlify/) and [stale-while-revalidate](https://www.netlify.com/blog/swr-and-fine-grained-cache-control/). 
-Any page or data can be rebuilt only when needed, without site visitors ever getting a performance hit.
-`;
 ---
 
-<Layout title="Welcome to Astro.">
-    <ContextAlert class="mb-4" />
-    <h1 class="mb-10">Netlify Platform Starter for Astro</h1>
-    <Markdown content={explainer} class="text-lg mb-10" />
-    <p class="mb-8">
-        <a href="https://docs.netlify.com/frameworks/astro/" class="btn btn-lg btn-primary sm:btn-wide">Read the Docs</a>
-    </p>
+<Layout title="Welcome">
+    <h1 class="mb-6">Welcome to Our Store</h1>
+    <p class="mb-8">Welcome to our store. We offer great products shipped worldwide.</p>
+    <a href="/order" class="btn btn-primary">Order Now</a>
 </Layout>

--- a/src/pages/order.astro
+++ b/src/pages/order.astro
@@ -1,0 +1,22 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Order">
+    <h1 class="mb-6">Place Your Order</h1>
+    <form class="flex flex-col gap-4 max-w-md" method="post" action="#">
+        <label>
+            Name
+            <input type="text" name="name" class="input input-bordered w-full" required />
+        </label>
+        <label>
+            Email
+            <input type="email" name="email" class="input input-bordered w-full" required />
+        </label>
+        <label>
+            Quantity
+            <input type="number" name="quantity" class="input input-bordered w-full" min="1" value="1" required />
+        </label>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+</Layout>


### PR DESCRIPTION
## Summary
- add a brief description about the landing and order pages in README
- add Order page link to navigation
- simplify the landing page
- add a new order form page

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_686de9028edc83318a3e2931398026b4